### PR TITLE
Bump version psr/log to 1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"php": ">=5.3.0",
 		"ext-curl": "*",
 		"ext-json": "*",
-		"psr/log": "1.0.2"
+		"psr/log": "1.1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "4.8.*"


### PR DESCRIPTION
Having problem with psr/log version on my end

```
Problem 1
    - paymaya/paymaya-sdk 0.0.2 requires psr/log 1.0.2 -> satisfiable by psr/log[1.0.2].
    - Conclusion: don't install psr/log 1.0.2
    - Can only install one of: psr/log[1.1.0, 1.0.0].
    - Can only install one of: psr/log[1.0.0, 1.1.0].
    - Can only install one of: psr/log[1.0.0, 1.1.0].
    - paymaya/paymaya-sdk 0.0.1 requires psr/log 1.0.0 -> satisfiable by psr/log[1.0.0].
    - Installation request for paymaya/paymaya-sdk * -> satisfiable by paymaya/paymaya-sdk[0.0.1, 0.0.2].
    - Installation request for psr/log (locked at 1.1.0) -> satisfiable by psr/log[1.1.0].
```

or I could make it `~1.0`